### PR TITLE
configure django settings based on AWS instance tags

### DIFF
--- a/aws.yml
+++ b/aws.yml
@@ -12,7 +12,7 @@
     ami_id: "{{ regions[region].ami_id }}"
     lc_num: 23
 
-    elb_ssl_arn: "arn:aws:acm:eu-west-2:929325949831:certificate/e373b9cf-d3b0-4f3d-9dd9-cce55239182d"
+    elb_ssl_arn: "arn:aws:acm:eu-west-2:929325949831:certificate/f353d7fd-fc69-44da-91c5-2bf8225e44ce"
     old_lc_num: "{{ lc_num - 1 }}"
     aws_env: "{{ lookup('env', 'ENVIRONMENT') or 'test' }}"
 

--- a/packer.json
+++ b/packer.json
@@ -27,7 +27,8 @@
       },
       "run_tags": {
         "application": "{{user `app_name` }}",
-        "Name": "packer-ami-build"
+        "Name": "packer-ami-build",
+        "Env": "packer-ami-build"
       },
       "run_volume_tags": {
         "application": "{{user `app_name` }}",

--- a/webapp_settings/production.py
+++ b/webapp_settings/production.py
@@ -1,6 +1,22 @@
 from .base import *
+from ec2_tag_conditional.util import InstanceTags
 import socket
 
+
+def get_env():
+    tags = InstanceTags()
+    server_env = None
+    if tags['Env']:
+        server_env = tags['Env']
+
+    if server_env not in ['test', 'prod', 'packer-ami-build']:
+        # if we can't work out our environment, don't attempt to guess
+        # fail to bootstrap the application and complain loudly about it
+        raise Exception('Failed to infer a valid environment')
+    return server_env
+
+
+# settings that are the same across all instance types
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
@@ -12,32 +28,56 @@ ADMINS = (
 )
 MANAGERS = ADMINS
 
-local_ip_addresses = [(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close())[1] for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]]
-ALLOWED_HOSTS = local_ip_addresses + [
-    "elections.democracyclub.org.uk",
-    "www.elections.democracyclub.org.uk",
-]
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': '{{ project_name }}',
-        'USER': '{{ project_name }}',
-        'PASSWORD': '{{ vault_DATABASE_PASSWORD }}',
-        'HOST': '{{ vault_DATABASE_HOST }}',
-        'PORT': '5432',
-    }
-}
-
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 PIPELINE['SASS_BINARY'] = "/var/www/{{ project_name }}/env/bin/sassc"
 PIPELINE['JS_COMPRESSOR'] = "pipeline.compressors.jsmin.JSMinCompressor"
 
 GCS_API_KEY = '{{ vault_GCS_API_KEY }}'
 
-SLACK_WEBHOOK_URL = '{{ vault_SLACK_WEBHOOK_URL }}'
-
 AWS_ACCESS_KEY_ID = '{{ vault_AWS_ACCESS_KEY_ID }}'
 AWS_SECRET_ACCESS_KEY = '{{ vault_AWS_SECRET_ACCESS_KEY }}'
 
 EMAIL_SIGNUP_API_KEY = '{{ vault_EMAIL_SIGNUP_API_KEY }}'
+
+
+# infer environment from the EC2 tags
+SERVER_ENVIRONMENT = get_env()
+
+
+# settings that are conditional on env
+
+local_ip_addresses = [(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close())[1] for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]]
+if SERVER_ENVIRONMENT == 'packer-ami-build':
+    ALLOWED_HOSTS = ['*']
+if SERVER_ENVIRONMENT == 'test':
+    ALLOWED_HOSTS = local_ip_addresses + [
+        "stage.elections.democracyclub.org.uk",
+    ]
+if SERVER_ENVIRONMENT == 'prod':
+    ALLOWED_HOSTS = local_ip_addresses + [
+        "elections.democracyclub.org.uk",
+        "www.elections.democracyclub.org.uk",
+    ]
+
+
+if SERVER_ENVIRONMENT == 'packer-ami-build':
+    DATABASES = {}
+if SERVER_ENVIRONMENT in ['prod', 'test']:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'NAME': '',
+            'USER': '{{ project_name }}',
+            'PASSWORD': '{{ vault_DATABASE_PASSWORD }}',
+            'HOST': '{{ vault_DATABASE_HOST }}',
+            'PORT': '5432',
+        }
+    }
+    if SERVER_ENVIRONMENT == 'prod':
+        DATABASES['default']['NAME'] = '{{ project_name }}'
+    if SERVER_ENVIRONMENT == 'test':
+        DATABASES['default']['NAME'] = 'ee_staging'
+
+
+if SERVER_ENVIRONMENT == 'prod':
+    SLACK_WEBHOOK_URL = '{{ vault_SLACK_WEBHOOK_URL }}'


### PR DESCRIPTION
This uses `ec2_tag_conditional` to set django vars based on AWS tags. This is the bit that is easy to do. I've not looked at how (if) we can do this with nginx settings yet.