### PR TITLE
Automatically rebuild the staging DB

### DIFF
--- a/crontab.yml
+++ b/crontab.yml
@@ -30,6 +30,13 @@
       minute: 8
       job: '/usr/local/bin/instance-tags "Env=prod" && /usr/local/bin/instance-tags "controller=True" && output-on-error ~/backup_db_to_s3.sh'
 
+  - name: "Schedule 'Rebuild Staging DB' job"
+    cron:
+      name: "Rebuild Staging DB"
+      hour: 4
+      minute: 45
+      job: '/usr/local/bin/instance-tags "Env=prod" && /usr/local/bin/instance-tags "controller=True" && output-on-error ~/rebuild_staging_db.sh'
+
   - name: "Schedule 'Generate map layers and sync to S3' job"
     cron:
       name: "Generate map layers and sync to S3"

--- a/files/scripts/rebuild_staging_db.sh
+++ b/files/scripts/rebuild_staging_db.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+export PGPASSWORD={{ vault_DATABASE_PASSWORD }}
+
+# Drop and re-create the staging DB
+dropdb -U {{ project_name }} --host={{ vault_DEFAULT_DATABASE_HOST }} {{ staging_db_name }}
+createdb -U {{ project_name }} --host={{ vault_DEFAULT_DATABASE_HOST }} {{ staging_db_name }}
+
+# Dump the prod DB and load it into staging
+pg_dump -U {{ project_name }} --host={{ vault_DEFAULT_DATABASE_HOST }} {{ project_name }} | psql -U {{ project_name }} --host={{ vault_DEFAULT_DATABASE_HOST }} -d {{ staging_db_name }}

--- a/provision.yml
+++ b/provision.yml
@@ -151,6 +151,14 @@
       group: every_election
       mode: 0755
 
+  - name: Install rebuild_staging_db script
+    template:
+      src: "files/scripts/rebuild_staging_db.sh"
+      dest: "{{ project_root }}/home/rebuild_staging_db.sh"
+      owner: every_election
+      group: every_election
+      mode: 0755
+
   - name: Install sync_map_layers_to_s3
     template:
       src: "files/scripts/sync_map_layers_to_s3.sh"

--- a/vars.yml
+++ b/vars.yml
@@ -1,6 +1,7 @@
 ---
 ansible_python_interpreter: /usr/bin/python3
 project_name: every_election
+staging_db_name: ee_staging
 project_root: /var/www/every_election
 app_name: every_election
 project_repo: https://github.com/DemocracyClub/EveryElection.git

--- a/webapp_settings/production.py
+++ b/webapp_settings/production.py
@@ -117,8 +117,8 @@ if SERVER_ENVIRONMENT in ['prod', 'test']:
         DATABASES['default']['NAME'] = '{{ project_name }}'
         DATABASES['replicas']['NAME'] = '{{ project_name }}'
     if SERVER_ENVIRONMENT == 'test':
-        DATABASES['default']['NAME'] = 'ee_staging'
-        DATABASES['replicas']['NAME'] = 'ee_staging'
+        DATABASES['default']['NAME'] = '{{ staging_db_name }}'
+        DATABASES['replicas']['NAME'] = '{{ staging_db_name }}'
     DATABASE_ROUTERS = ["every_election.db_routers.DbRouter"]
 
 


### PR DESCRIPTION
The EE RDS instance has 2 DBs on it: prod and staging. I've been periodically dumping the prod DB to staging so we've got some data to play with when testing a stagin deploy. I was going to write some docs on this, but then I figured it would be better to just automate that process.

This will also give us a more realistic base for testing deploys that include a migration.

- Move staging DB name to a variable
- Add a script to dump the prod DB into staging
- Schedule it to run at 4:45 am every day